### PR TITLE
Use c3p0 for Hibernate MySQL connection pooling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
     compile 'org.hibernate:hibernate-core:5.4.21.Final'
+    compile 'org.hibernate:hibernate-c3p0:5.4.21.Final'
     compile group: 'javax.persistence', name: 'javax.persistence-api', version: '2.2'
     compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.4'
     compile 'redis.clients:jedis:3.2.0'

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/MySQLDatabase.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/MySQLDatabase.java
@@ -83,6 +83,13 @@ public class MySQLDatabase extends DatabaseProvider {
         prop.setProperty("hibernate.hbm2ddl.auto", "update");
         prop.setProperty("show_sql", "true");
         prop.setProperty("format_sql", "true");
+
+        // Start with just one connection (default is three)
+        prop.setProperty("hibernate.c3p0.min_size", "1");
+
+        // When the pool is exhausted, create one new connection (default is three)
+        prop.setProperty("hibernate.c3p0.acquire_increment", "1");
+
         configuration = new Configuration().addProperties(prop);
         configuration.addAnnotatedClass(EventSetting.class);
         configuration.addAnnotatedClass(EventPlayer.class);


### PR DESCRIPTION
We were using Hibernate's default connection pool which seems very basic and is documented as not fit for production. c3p0 is the next step up (it sounds like it used to be included by default) and should properly test connections to make sure new ones are opened if an old one times out.

Adding the dependency is all that's needed, I also tweaked a few of the properties as a better starting point for smaller servers. These would need changing for a larger event.