### PR TITLE
Add AnnouncementsModule

### DIFF
--- a/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/AnnouncementsModule.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/AnnouncementsModule.java
@@ -1,0 +1,68 @@
+package dev.imabad.mceventsuite.core.modules.announcements;
+
+import dev.imabad.mceventsuite.core.EventCore;
+import dev.imabad.mceventsuite.core.api.modules.Module;
+import dev.imabad.mceventsuite.core.modules.announcements.db.ScheduledAnnouncement;
+import dev.imabad.mceventsuite.core.modules.announcements.db.ScheduledAnnouncementDAO;
+import dev.imabad.mceventsuite.core.modules.mysql.MySQLDatabase;
+import dev.imabad.mceventsuite.core.modules.mysql.MySQLModule;
+import dev.imabad.mceventsuite.core.modules.mysql.events.MySQLLoadedEvent;
+
+import java.util.*;
+
+public class AnnouncementsModule extends Module {
+
+    private MySQLDatabase mySQLDatabase;
+    private ScheduledAnnouncementDAO dao;
+    private PriorityQueue<ScheduledAnnouncement> announcements = new PriorityQueue<>();
+
+    @Override
+    public String getName() {
+        return "announcements";
+    }
+
+    @Override
+    public void onEnable() {
+        mySQLDatabase = EventCore.getInstance().getModuleRegistry().getModule(MySQLModule.class).getMySQLDatabase();
+        EventCore.getInstance().getEventRegistry().registerListener(MySQLLoadedEvent.class, mySQLLoadedEvent -> {
+            dao = new ScheduledAnnouncementDAO(mySQLDatabase);
+            mySQLDatabase.registerDAOs(dao);
+
+            for (ScheduledAnnouncement announcement : dao.getAllScheduledAnnouncements()) {
+                // Skip over any missed broadcasts
+                if (announcement.getNextRun() < System.currentTimeMillis()) {
+                    double missedAnnouncements = (System.currentTimeMillis() - announcement.getNextRun())
+                                    / announcement.getInterval();
+                    announcement.setNextRun(announcement.getNextRun()
+                            + Math.round(Math.ceil(missedAnnouncements) * announcement.getInterval()));
+                    dao.saveOrUpdateScheduledAnnouncement(announcement);
+                }
+
+                announcements.add(announcement);
+            }
+
+            if (announcements.peek() != null) {
+                System.out.println("Next announcement scheduled for: " + new Date(announcements.peek().getNextRun()));
+            }
+        });
+    }
+
+    @Override
+    public void onDisable() {
+        announcements.clear();
+    }
+
+    @Override
+    public List<Class<? extends Module>> getDependencies() {
+        return Arrays.asList(MySQLModule.class);
+    }
+
+    public PriorityQueue<ScheduledAnnouncement> getAnnouncements() {
+        return this.announcements;
+    }
+
+    protected ScheduledAnnouncementDAO getDao() {
+        return this.dao;
+    }
+
+}

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/ScheduledAnnouncementsRunnable.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/ScheduledAnnouncementsRunnable.java
@@ -1,0 +1,34 @@
+package dev.imabad.mceventsuite.core.modules.announcements;
+
+import dev.imabad.mceventsuite.core.modules.announcements.db.ScheduledAnnouncement;
+
+import java.util.PriorityQueue;
+
+public abstract class ScheduledAnnouncementsRunnable implements Runnable {
+
+    private AnnouncementsModule module;
+
+    public ScheduledAnnouncementsRunnable(AnnouncementsModule module) {
+        this.module = module;
+    }
+
+    public abstract void broadcastMessage(String message);
+
+    @Override
+    public void run() {
+        PriorityQueue<ScheduledAnnouncement> announcements = module.getAnnouncements();
+
+        if (announcements.size() == 0) return;
+
+        while (announcements.peek().getNextRun() <= System.currentTimeMillis()) {
+            ScheduledAnnouncement announcement = announcements.poll();
+
+            this.broadcastMessage(announcement.getMessage());
+
+            announcement.setNextRun(System.currentTimeMillis() + announcement.getInterval());
+            module.getDao().saveOrUpdateScheduledAnnouncement(announcement);
+            announcements.add(announcement);
+        }
+    }
+
+}

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/db/ScheduledAnnouncement.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/db/ScheduledAnnouncement.java
@@ -1,0 +1,66 @@
+package dev.imabad.mceventsuite.core.modules.announcements.db;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "scheduled_announcements")
+public class ScheduledAnnouncement implements Comparable<ScheduledAnnouncement> {
+
+    private String id;
+    private String message;
+    private long interval;
+    private long nextRun;
+
+    public ScheduledAnnouncement() {
+
+    }
+
+    public ScheduledAnnouncement(String message, long interval, long nextRun) {
+        this.id = UUID.randomUUID().toString();
+        this.message = message;
+        this.interval = interval;
+        this.nextRun = nextRun;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Id
+    public String getId() {
+        return this.id;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public long getInterval() {
+        return this.interval;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+
+    public long getNextRun() {
+        return this.nextRun;
+    }
+
+    public void setNextRun(long nextRun) {
+        this.nextRun = nextRun;
+    }
+
+    @Override
+    public int compareTo(ScheduledAnnouncement other) {
+        return Long.compare(this.nextRun, other.nextRun);
+    }
+
+}

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/db/ScheduledAnnouncementDAO.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/announcements/db/ScheduledAnnouncementDAO.java
@@ -1,0 +1,41 @@
+package dev.imabad.mceventsuite.core.modules.announcements.db;
+
+import dev.imabad.mceventsuite.core.modules.mysql.MySQLDatabase;
+import dev.imabad.mceventsuite.core.modules.mysql.dao.DAO;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.query.Query;
+
+import java.util.List;
+
+public class ScheduledAnnouncementDAO extends DAO {
+
+    public ScheduledAnnouncementDAO(MySQLDatabase mySQLDatabase){
+        super(mySQLDatabase);
+    }
+
+    public List<ScheduledAnnouncement> getAllScheduledAnnouncements(){
+        try (Session session = mySQLDatabase.getSession()) {
+            Query<ScheduledAnnouncement> query = session.createQuery("select a from ScheduledAnnouncement a", ScheduledAnnouncement.class);
+            return query.getResultList();
+        }
+    }
+
+    public void saveOrUpdateScheduledAnnouncement(ScheduledAnnouncement scheduledAnnouncement){
+        Session session = mySQLDatabase.getSession();
+        Transaction tx = null;
+        try {
+            tx = session.beginTransaction();
+            session.saveOrUpdate(scheduledAnnouncement);
+            tx.commit(); // Flush happens automatically
+        }
+        catch (RuntimeException e) {
+            tx.rollback();
+            e.printStackTrace();
+        }
+        finally {
+            session.close();
+        }
+    }
+
+}

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/MySQLDatabase.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/MySQLDatabase.java
@@ -7,6 +7,7 @@ import dev.imabad.mceventsuite.core.api.objects.*;
 import dev.imabad.mceventsuite.core.config.database.MySQLConfig;
 import dev.imabad.mceventsuite.core.modules.ac.db.AccessControlSetting;
 import dev.imabad.mceventsuite.core.modules.ac.db.PlayerBan;
+import dev.imabad.mceventsuite.core.modules.announcements.db.ScheduledAnnouncement;
 import dev.imabad.mceventsuite.core.modules.audit.db.AuditLogEntry;
 import dev.imabad.mceventsuite.core.modules.discord.DiscordLink;
 import dev.imabad.mceventsuite.core.modules.mysql.dao.*;
@@ -97,6 +98,7 @@ public class MySQLDatabase extends DatabaseProvider {
         configuration.addAnnotatedClass(AuditLogEntry.class);
         configuration.addAnnotatedClass(DiscordLink.class);
         configuration.addAnnotatedClass(EventBoothPlot.class);
+        configuration.addAnnotatedClass(ScheduledAnnouncement.class);
         configuration.addPackage("dev.imabad.mceventsuite");
         sessionFactory = configuration.buildSessionFactory();
         EventCore.getInstance().getEventRegistry().handleEvent(new MySQLLoadedEvent(this));


### PR DESCRIPTION
Adds the "announcements" module with basic support for timed messages. This PR handles loading announcements from the database and providing an abstract class which can decide which announcements to broadcast at a given instant in time. The `ScheduledAnnouncementsRunnable` added here can then be scheduled by a consumer to actually broadcast messages (see upcoming EventBungee PR).