### PR TITLE
WIP: Remove Hibernate and write queries ourselves.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,9 @@ repositories {
 }
 
 dependencies {
-    compile 'org.hibernate:hibernate-core:5.4.21.Final'
-    compile 'org.hibernate:hibernate-c3p0:5.4.21.Final'
-    compile group: 'javax.persistence', name: 'javax.persistence-api', version: '2.2'
-    compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.4'
+    compile 'com.zaxxer:HikariCP:3.4.5'
     compile 'redis.clients:jedis:3.2.0'
     compile "com.influxdb:influxdb-client-java:1.13.0"
-    runtime 'mysql:mysql-connector-java:5.1.37'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'net.kyori:adventure-api:4.1.1'
 

--- a/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventBooth.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventBooth.java
@@ -1,11 +1,8 @@
 package dev.imabad.mceventsuite.core.api.objects;
 
-import javax.persistence.*;
 import java.util.List;
 import java.util.UUID;
 
-@Entity
-@Table(name = "booths")
 public class EventBooth {
 
     private String id;
@@ -16,8 +13,6 @@ public class EventBooth {
     private String plotID;
     private String status = "un-assigned";
 
-    protected EventBooth(){}
-
     public EventBooth(String name, String boothType, EventPlayer owner, List<EventPlayer> members){
         this.id = UUID.randomUUID().toString();
         this.name = name;
@@ -26,11 +21,17 @@ public class EventBooth {
         this.members = members;
     }
 
+    public EventBooth(String id, String name, String boothType, EventPlayer owner, List<EventPlayer> members, String plotID, String status){
+        this(name, boothType, owner, members);
+        this.id = id;
+        this.plotID = plotID;
+        this.status = status;
+    }
+
     public void setId(String id) {
         this.id = id;
     }
 
-    @Id
     public String getId() {
         return id;
     }
@@ -51,7 +52,6 @@ public class EventBooth {
         this.boothType = boothType;
     }
 
-    @OneToOne(fetch = FetchType.EAGER)
     public EventPlayer getOwner() {
         return owner;
     }
@@ -60,7 +60,6 @@ public class EventBooth {
         this.owner = owner;
     }
 
-    @ManyToMany(fetch = FetchType.EAGER)
     public List<EventPlayer> getMembers() {
         return members;
     }

--- a/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventBoothPlot.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventBoothPlot.java
@@ -1,10 +1,8 @@
 package dev.imabad.mceventsuite.core.api.objects;
 
-import javax.persistence.*;
 import java.util.UUID;
 
-@Entity
-@Table(name = "booth_plots")
+//TODO: Move into a separate module
 public class EventBoothPlot {
 
     private String id;
@@ -14,8 +12,6 @@ public class EventBoothPlot {
     private String frontPos;
     private String status = "empty";
     private EventBooth booth;
-
-    protected EventBoothPlot(){}
 
     public EventBoothPlot(String boothType, String posOne, String posTwo){
         this.id = UUID.randomUUID().toString();
@@ -28,7 +24,6 @@ public class EventBoothPlot {
         this.id = id;
     }
 
-    @Id
     public String getId() {
         return id;
     }
@@ -41,7 +36,6 @@ public class EventBoothPlot {
         this.boothType = boothType;
     }
 
-    @OneToOne(fetch = FetchType.EAGER)
     public EventBooth getBooth() {
         return booth;
     }
@@ -82,6 +76,7 @@ public class EventBoothPlot {
         this.frontPos = frontPos;
     }
 
+    //TODO: Come back and rewrite this to not be hard-coded
     public int plotSize(){
         switch(boothType){
             case "small":

--- a/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventRank.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventRank.java
@@ -1,11 +1,8 @@
 package dev.imabad.mceventsuite.core.api.objects;
 
-
-import javax.persistence.*;
 import java.util.List;
 
-@Entity
-@Table(name = "ranks")
+//TODO: Remove XP from here.
 public class EventRank {
 
     private int id;
@@ -17,7 +14,6 @@ public class EventRank {
     private List<String> permissions;
     private boolean inheritsFromBelow = true;
     private int initialEventPassXP = 0;
-
 
     public EventRank(int power, String name, String prefix, String suffix, List<String> permissions, boolean inheritsFromBelow) {
         this.power = power;
@@ -34,32 +30,24 @@ public class EventRank {
         this(power, name, prefix, suffix, permissions, true);
     }
 
-    public EventRank(int id, int power, String name, String prefix, String suffix, List<String> permissions, boolean inheritsFromBelow){
+    public EventRank(int id, int power, String name, String prefix, String suffix, List<String> permissions, boolean inheritsFromBelow, String chatColor){
         this(power, name, prefix, suffix, permissions, inheritsFromBelow);
         this.id = id;
+        this.chatColor = chatColor;
     }
 
-    public EventRank() {
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", unique = true)
     public int getId() {
         return id;
     }
 
-    @Column(name = "power")
     public int getPower() {
         return power;
     }
 
-    @Column(name = "name")
     public String getName() {
         return name;
     }
 
-    @Column(name = "prefix")
     public String getPrefix() {
         if(prefix == null){
             return "";
@@ -67,7 +55,6 @@ public class EventRank {
         return prefix;
     }
 
-    @Column(name = "suffix")
     public String getSuffix() {
         if(suffix == null){
             return "";
@@ -75,17 +62,14 @@ public class EventRank {
         return suffix;
     }
 
-    @ElementCollection(fetch = FetchType.EAGER)
     public List<String> getPermissions() {
         return permissions;
     }
 
-    @Column(name = "inheritsFromBelow")
     public boolean isInheritsFromBelow() {
         return inheritsFromBelow;
     }
 
-    @Column(name = "chatColor")
     public String getChatColor() {
         if(chatColor == null){
             return "#fff";
@@ -93,7 +77,6 @@ public class EventRank {
         return chatColor;
     }
 
-    @Column(name = "initialXP")
     public int getInitialEventPassXP() {
         return initialEventPassXP;
     }
@@ -134,6 +117,7 @@ public class EventRank {
         this.initialEventPassXP = initialEventPassXP;
     }
 
+    //TODO: Modify this to allow for negated permissions
     private boolean containsPermission(String permission){
         return this.permissions.contains(permission) || (!this.permissions.contains('-' + permission) && this.permissions.contains('+' + permission));
     }

--- a/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventSetting.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/api/objects/EventSetting.java
@@ -1,16 +1,7 @@
 package dev.imabad.mceventsuite.core.api.objects;
 
-
-import com.google.gson.Gson;
 import dev.imabad.mceventsuite.core.util.GsonUtils;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
-@Entity
-@Table(name = "event_settings")
 public class EventSetting {
 
     private String name;
@@ -25,10 +16,13 @@ public class EventSetting {
         this.permission = permission;
     }
 
-    public EventSetting() {
+    public EventSetting(String group, String name, String value, String permission){
+        this.group = group;
+        this.name = name;
+        this.value = value;
+        this.permission = permission;
     }
 
-    @Column(name = "group")
     public String getGroup() {
         return group;
     }
@@ -37,8 +31,6 @@ public class EventSetting {
         this.group = group;
     }
 
-    @Id
-    @Column(name = "name")
     public String getName() {
         return name;
     }
@@ -47,8 +39,7 @@ public class EventSetting {
         this.name = name;
     }
 
-    @Column(name = "value")
-    private String getValue() {
+    public String getValueJSON() {
         return value;
     }
 
@@ -60,7 +51,6 @@ public class EventSetting {
         this.value =  GsonUtils.getGson().toJson(value);
     }
 
-    @Column(name = "permission")
     public String getPermission() {
         return permission;
     }

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/MySQLModule.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/MySQLModule.java
@@ -3,7 +3,7 @@ package dev.imabad.mceventsuite.core.modules.mysql;
 import dev.imabad.mceventsuite.core.api.IConfigProvider;
 import dev.imabad.mceventsuite.core.api.modules.Module;
 import dev.imabad.mceventsuite.core.config.database.MySQLConfig;
-
+import dev.imabad.mceventsuite.core.modules.mysql.dao.DAO;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,8 +85,11 @@ public class MySQLModule extends Module implements IConfigProvider<MySQLConfig> 
         return false;
     }
 
-
     public MySQLDatabase getMySQLDatabase() {
         return mySQLDatabase;
+    }
+
+    public <T extends DAO> T getDAO(Class<T> dao){
+        return mySQLDatabase.getDAO(dao);
     }
 }

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/dao/BoothDAO.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/dao/BoothDAO.java
@@ -5,28 +5,54 @@ import dev.imabad.mceventsuite.core.api.objects.EventBoothPlot;
 import dev.imabad.mceventsuite.core.api.objects.EventPlayer;
 import dev.imabad.mceventsuite.core.api.objects.EventRank;
 import dev.imabad.mceventsuite.core.modules.mysql.MySQLDatabase;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
-import org.hibernate.query.Query;
-
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import dev.imabad.mceventsuite.core.util.GsonUtils;
+import dev.imabad.mceventsuite.core.util.PropertyMap;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import redis.clients.jedis.Transaction;
 
+//TODO: Move into booths module
 public class BoothDAO extends DAO {
 
     public BoothDAO(MySQLDatabase mySQLDatabase){
         super(mySQLDatabase);
     }
 
-    public List<EventBooth> getBooths(){
-        Session session = mySQLDatabase.getSession();
-        try {
-            return session.createQuery("select r from EventBooth r LEFT JOIN FETCH r.owner.permissions e", EventBooth.class).list();
-        } finally {
-            session.close();
+    public Collection<EventBooth> getBooths(int perPage, int page){
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM booths INNER JOIN booths_players ON booths.id=booths_players.EventBooth_id LIMIT ? OFFSET ?");
+            statement.setInt(1, perPage);
+            statement.setInt(2, (perPage * page) - perPage);
+            ResultSet resultSet = statement.executeQuery();
+            Map<String, EventBooth> boothMap = new HashMap<>();
+            while(resultSet.next()){
+                String uuid = resultSet.getString("id");
+                EventBooth eventBooth = boothMap.get(uuid);
+                if(eventBooth == null){
+                    String boothType = resultSet.getString("boothType");
+                    String name = resultSet.getString("name");
+                    String plotID = resultSet.getString("plotID");
+                    String status = resultSet.getString("status");
+                    String ownerUUID = resultSet.getString("owner_uuid");
+                    EventPlayer owner = mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString(ownerUUID));
+                    List<EventPlayer> members = new ArrayList<>();
+                    eventBooth = new EventBooth(uuid, name, boothType, owner, members, plotID, status);
+                    boothMap.put(uuid, eventBooth);
+                }
+                eventBooth.getMembers().add(mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString("members_uuid")));
+            }
+            return boothMap.values();
+        } catch (SQLException throwables) {
+            return Collections.emptyList();
         }
     }
 
@@ -40,28 +66,81 @@ public class BoothDAO extends DAO {
     }
 
     public EventBooth getBoothFromID(UUID uuid){
-        try(Session session = mySQLDatabase.getSession()){
-            Query<EventBooth> boothQuery = session.createQuery("select r from EventBooth r LEFT JOIN FETCH r.owner.permissions e where r.id = :uuid ", EventBooth.class);
-            boothQuery.setParameter("uuid", uuid.toString());
-            return boothQuery.getSingleResult();
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM booths INNER JOIN booths_players ON booths.id=booths_players.EventBooth_id WHERE id = ?");
+            statement.setString(1, uuid.toString());
+            ResultSet resultSet = statement.executeQuery();
+            EventBooth booth = null;
+            while(resultSet.next()){
+                if(booth == null){
+                    String boothType = resultSet.getString("boothType");
+                    String name = resultSet.getString("name");
+                    String plotID = resultSet.getString("plotID");
+                    String status = resultSet.getString("status");
+                    String ownerUUID = resultSet.getString("owner_uuid");
+                    EventPlayer owner = mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString(ownerUUID));
+                    List<EventPlayer> members = new ArrayList<>();
+                    booth = new EventBooth(uuid.toString(), name, boothType, owner, members, plotID, status);
+                }
+                booth.getMembers().add(mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString("members_uuid")));
+            }
+            return booth;
+        } catch (SQLException throwables) {
+            return null;
         }
     }
 
-    public List<EventBooth> getPlayerBooths(EventPlayer player){
-        try(Session session = mySQLDatabase.getSession()){
-            Query<EventBooth> boothQuery = session.createQuery("select r from EventBooth r where :player MEMBER OF r.members OR r.owner = :player", EventBooth.class);
-            boothQuery.setParameter("player", player);
-            return boothQuery.getResultList();
+    public Collection<EventBooth> getPlayerBooths(EventPlayer player){
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM booths INNER JOIN booths_players ON booths.id=booths_players.EventBooth_id WHERE owner_uuid = ? OR WHERE booths.id IN (SELECT EventBooth_id FROM booths_players WHERE booths_players.members_uuid = ?)");
+            statement.setString(1, player.getUUID().toString());
+            statement.setString(2, player.getUUID().toString());
+            ResultSet resultSet = statement.executeQuery();
+            Map<String, EventBooth> boothMap = new HashMap<>();
+            while(resultSet.next()){
+                String uuid = resultSet.getString("id");
+                EventBooth eventBooth = boothMap.get(uuid);
+                if(eventBooth == null){
+                    String boothType = resultSet.getString("boothType");
+                    String name = resultSet.getString("name");
+                    String plotID = resultSet.getString("plotID");
+                    String status = resultSet.getString("status");
+                    String ownerUUID = resultSet.getString("owner_uuid");
+                    EventPlayer owner = mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString(ownerUUID));
+                    List<EventPlayer> members = new ArrayList<>();
+                    eventBooth = new EventBooth(uuid, name, boothType, owner, members, plotID, status);
+                    boothMap.put(uuid, eventBooth);
+                }
+                eventBooth.getMembers().add(mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString("members_uuid")));
+            }
+            return boothMap.values();
+        } catch (SQLException throwables) {
+            return Collections.emptyList();
         }
     }
 
     public EventBooth getBoothFromPlotID(String type, String plotID){
-        try(Session session = mySQLDatabase.getSession()){
-            Query<EventBooth> boothQuery = session.createQuery("select r from EventBooth r where r.boothType = :type and r.plotID = :plotID", EventBooth.class);
-            boothQuery.setParameter("type", type);
-            boothQuery.setParameter("plotID", plotID);
-            return boothQuery.getSingleResult();
-        }catch(Exception e){
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM booths INNER JOIN booths_players ON booths.id=booths_players.EventBooth_id WHERE boothType = ? AND plotID = ?");
+            statement.setString(1, type);
+            statement.setString(2, plotID);
+            ResultSet resultSet = statement.executeQuery();
+            EventBooth booth = null;
+            while(resultSet.next()){
+                if(booth == null){
+                    String boothType = resultSet.getString("boothType");
+                    String uuid = resultSet.getString("uuid");
+                    String name = resultSet.getString("name");
+                    String status = resultSet.getString("status");
+                    String ownerUUID = resultSet.getString("owner_uuid");
+                    EventPlayer owner = mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString(ownerUUID));
+                    List<EventPlayer> members = new ArrayList<>();
+                    booth = new EventBooth(uuid, name, boothType, owner, members, plotID, status);
+                }
+                booth.getMembers().add(mySQLDatabase.getDAO(PlayerDAO.class).getPlayer(UUID.fromString("members_uuid")));
+            }
+            return booth;
+        } catch (SQLException throwables) {
             return null;
         }
     }

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/dao/PlayerDAO.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/dao/PlayerDAO.java
@@ -1,15 +1,22 @@
 package dev.imabad.mceventsuite.core.modules.mysql.dao;
 
 import dev.imabad.mceventsuite.core.api.objects.EventPlayer;
+import dev.imabad.mceventsuite.core.api.objects.EventRank;
 import dev.imabad.mceventsuite.core.modules.mysql.MySQLDatabase;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
-import org.hibernate.query.Query;
-
-import javax.persistence.NoResultException;
+import dev.imabad.mceventsuite.core.util.GsonUtils;
+import dev.imabad.mceventsuite.core.util.PropertyMap;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class PlayerDAO extends DAO {
 
@@ -17,19 +24,40 @@ public class PlayerDAO extends DAO {
         super(mySQLDatabase);
     }
 
+    public Collection<EventPlayer> getPlayers(){
+        return getPlayers(20, 1);
+    }
+
     /**
-     * Get all players
+     * Get X amount of players offset by page
      * @return  A list of players
      * @see     EventPlayer
      */
-    public List<EventPlayer> getPlayers(){
-        try (Session session = mySQLDatabase.getSession()) {
-            Query<EventPlayer> q= session.createQuery("select p FROM EventPlayer p LEFT JOIN FETCH p.permissions e", EventPlayer.class);
-            try {
-                return q.getResultList();
-            } catch (NoResultException e) {
-                return Collections.emptyList();
+    public Collection<EventPlayer> getPlayers(int perPage, int page){
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM players INNER JOIN EventPlayer_permissions ON players.uuid=EventPlayer_permissions.EventPlayer_uuid LIMIT ? OFFSET ?");
+            statement.setInt(1, perPage);
+            statement.setInt(2, (perPage * page) - perPage);
+            ResultSet resultSet = statement.executeQuery();
+            Map<String, EventPlayer> playerMap = new HashMap<>();
+            while(resultSet.next()){
+                String uuid = resultSet.getString("uuid");
+                EventPlayer eventPlayer = playerMap.get(uuid);
+                if(eventPlayer == null){
+                    String lastUsername = resultSet.getString("last_username");
+                    String properties = resultSet.getString("properties");
+                    int rankID = resultSet.getInt("rank_id");
+                    EventRank rank = mySQLDatabase.getDAO(RankDAO.class).getRankByID(rankID);
+                    List<String> permissions = new ArrayList<>();
+                    PropertyMap propertyMap = GsonUtils.getGson().fromJson(properties, PropertyMap.class);
+                    eventPlayer = new EventPlayer(UUID.fromString(uuid), lastUsername, rank, permissions, propertyMap);
+                    playerMap.put(uuid, eventPlayer);
+                }
+                eventPlayer.getPermissions().add(resultSet.getString("permissions"));
             }
+            return playerMap.values();
+        } catch (SQLException throwables) {
+            return Collections.emptyList();
         }
     }
 
@@ -48,7 +76,7 @@ public class PlayerDAO extends DAO {
             eventPlayer = getPlayer(username);
             if (eventPlayer == null) {
                 eventPlayer = new EventPlayer(uuid, username);
-                savePlayer(eventPlayer);
+                saveNewPlayer(eventPlayer);
             } else {
                 if(!eventPlayer.getUUID().equals(uuid)){
                     eventPlayer.setUUID(uuid);
@@ -67,14 +95,27 @@ public class PlayerDAO extends DAO {
      * @see        EventPlayer
      */
     public EventPlayer getPlayer(UUID uuid){
-        try (Session session = mySQLDatabase.getSession()) {
-            Query<EventPlayer> q= session.createQuery("select p FROM EventPlayer p LEFT JOIN FETCH p.permissions e WHERE p.UUID = :uuid", EventPlayer.class);
-            q.setParameter("uuid", uuid);
-            try {
-                return q.getSingleResult();
-            } catch (NoResultException e) {
-                return null;
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM players INNER JOIN EventPlayer_permissions ON players.uuid=EventPlayer_permissions.EventPlayer_uuid WHERE uuid = ?");
+            statement.setString(1, uuid.toString());
+            ResultSet resultSet = statement.executeQuery();
+            EventPlayer player = null;
+            while(resultSet.next()){
+                if(player == null){
+                    String lastUsername = resultSet.getString("last_username");
+                    String properties = resultSet.getString("properties");
+                    int rankID = resultSet.getInt("rank_id");
+                    EventRank rank = mySQLDatabase.getDAO(RankDAO.class).getRankByID(rankID);
+                    List<String> permissions = new ArrayList<>();
+                    PropertyMap propertyMap = GsonUtils.getGson().fromJson(properties, PropertyMap.class);
+                    player = new EventPlayer(uuid, lastUsername, rank, permissions, propertyMap);
+                }
+                player.getPermissions().add(resultSet.getString("permissions"));
             }
+            return player;
+        } catch (SQLException e){
+            e.printStackTrace();
+            return null;
         }
     }
 
@@ -87,57 +128,110 @@ public class PlayerDAO extends DAO {
      * @see             EventPlayer
      */
     public EventPlayer getPlayer(String username){
-        try(Session session = mySQLDatabase.getSession()) {
-            System.out.println("Checking for player with username: " + username);
-            Query<EventPlayer> q = session.createQuery("select p FROM EventPlayer p LEFT JOIN FETCH p.permissions e WHERE p.lastUsername = :username",
-                    EventPlayer.class);
-            q.setParameter("username", username);
-            try {
-                return q.getSingleResult();
-            } catch (NoResultException e) {
-                return null;
+        try (Connection connection = mySQLDatabase.getSession()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM players INNER JOIN EventPlayer_permissions ON players.uuid=EventPlayer_permissions.EventPlayer_uuid WHERE last_username = ?");
+            statement.setString(1, username);
+            ResultSet resultSet = statement.executeQuery();
+            EventPlayer player = null;
+            while(resultSet.next()){
+                if(player == null){
+                    String uuid = resultSet.getString("uuid");
+                    String properties = resultSet.getString("properties");
+                    int rankID = resultSet.getInt("rank_id");
+                    EventRank rank = mySQLDatabase.getDAO(RankDAO.class).getRankByID(rankID);
+                    List<String> permissions = new ArrayList<>();
+                    PropertyMap propertyMap = GsonUtils.getGson().fromJson(properties, PropertyMap.class);
+                    player = new EventPlayer(UUID.fromString(uuid), username, rank, permissions, propertyMap);
+                }
+                player.getPermissions().add(resultSet.getString("permissions"));
             }
-        }
-    }
-
-    /**
-     * Saves an EventPlayer to the database
-     * You should avoid this where possible and ask the central service to do this for you
-     * @param player - The EventPlayer you wish to save
-     */
-    @Deprecated
-    public void saveOrUpdatePlayer(EventPlayer player){
-        Transaction tx = null;
-        try (Session session = mySQLDatabase.getSession()) {
-            tx = session.beginTransaction();
-            session.saveOrUpdate(player);
-            tx.commit(); // Flush happens automatically
-        } catch (RuntimeException e) {
-            assert tx != null;
-            tx.rollback();
-        }
-    }
-
-    /**
-     * Saves an EventPlayer to the database
-     * You should avoid this where possible and ask the central service to do this for you
-     * @param player - The EventPlayer you wish to save
-     */
-    @Deprecated
-    public void savePlayer(EventPlayer player){
-        Session session = mySQLDatabase.getSession();
-        Transaction tx = null;
-        try {
-            tx = session.beginTransaction();
-            session.save(player);
-            tx.commit(); // Flush happens automatically
-        }
-        catch (RuntimeException e) {
-            tx.rollback();
+            return player;
+        } catch (SQLException e){
             e.printStackTrace();
+            return null;
         }
-        finally {
-            session.close();
+    }
+
+    public boolean saveNewPlayer(EventPlayer player){
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement insertStatement = connection.prepareStatement("INSERT INTO players VALUES (?, ?, ?, ?);");
+            insertStatement.setString(1, player.getUUID().toString());
+            insertStatement.setString(2, player.getLastUsername());
+            insertStatement.setString(3, GsonUtils.getGson().toJson(player.getProperties()));
+            insertStatement.setInt(4, player.getRank().getId());
+            if(insertStatement.executeUpdate() == 0){
+                return false;
+            }
+            updatePlayerPermissions(player, false);
+        }catch(SQLException exception){
+            //TODO: Add proper logging
+            exception.printStackTrace();
+        }
+        return false;
+    }
+
+    public void savePlayer(EventPlayer eventPlayer){
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement insertStatement = connection.prepareStatement("UPDATE players SET last_username = ?, properties = ?, rank_id = ? WHERE uuid = ?");
+            insertStatement.setString(1, eventPlayer.getLastUsername());
+            insertStatement.setString(2, GsonUtils.getGson().toJson(eventPlayer.getProperties()));
+            insertStatement.setInt(4, eventPlayer.getRank().getId());
+            insertStatement.setString(4, eventPlayer.getUUID().toString());
+            insertStatement.executeUpdate();
+            updatePlayerPermissions(eventPlayer, true);
+        }catch(SQLException exception){
+            //TODO: Add proper logging
+            exception.printStackTrace();
+        }
+    }
+
+    public Collection<String> getPlayerPermissions(EventPlayer eventPlayer){
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement selectStatement = connection.prepareStatement("SELECT permissions FROM EventPlayer_permissions WHERE EventPlayer_uuid = ?");
+            selectStatement.setString(1, eventPlayer.getUUID().toString());
+            ResultSet resultSet = selectStatement.executeQuery();
+            Collection<String> permissions = new ArrayList<>();
+            while(resultSet.next()){
+                permissions.add(resultSet.getString("permissions"));
+            }
+            return permissions;
+        }catch (SQLException e){
+            return Collections.emptyList();
+        }
+    }
+
+    public void updatePlayerPermissions(EventPlayer eventPlayer, boolean isUpdate){
+        try(Connection connection = mySQLDatabase.getSession()){
+            Collection<String> toAdd = eventPlayer.getPermissions();
+            if(isUpdate){
+                Collection<String> existingPermissions = getPlayerPermissions(eventPlayer);
+                toAdd = toAdd.stream().filter(s -> !existingPermissions.contains(s)).collect(
+                    Collectors.toList());
+                Collection<String> toRemove = existingPermissions.stream().filter(s -> !eventPlayer.getPermissions().contains(s)).collect(
+                    Collectors.toList());
+                if(!toRemove.isEmpty()){
+                    PreparedStatement removeStatement = connection.prepareStatement("DELETE FROM EventPlayer_permissions WHERE EventPlayer_uuid = ? AND permissions IN (?)");
+                    removeStatement.setString(1, eventPlayer.getUUID().toString());
+                    removeStatement.setArray(2, connection.createArrayOf("VARCHAR", toRemove.toArray()));
+                    removeStatement.executeUpdate();
+                }
+            }
+            if(!toAdd.isEmpty()){
+                PreparedStatement addStatement = connection.prepareStatement("INSERT INTO EventPlayer_permissions VALUES(?,?)");
+                addStatement.setString(1, eventPlayer.getUUID().toString());
+                toAdd.forEach(s -> {
+                    try {
+                        addStatement.setString(2, s);
+                        addStatement.addBatch();
+                    } catch(SQLException exception){
+                        exception.printStackTrace();
+                    }
+                });
+                addStatement.executeBatch();
+            }
+        }catch(SQLException exception){
+            //TODO: Add proper logging
+            exception.printStackTrace();
         }
     }
 }

--- a/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/dao/RankDAO.java
+++ b/src/main/java/dev/imabad/mceventsuite/core/modules/mysql/dao/RankDAO.java
@@ -1,22 +1,24 @@
 package dev.imabad.mceventsuite.core.modules.mysql.dao;
 
-import dev.imabad.mceventsuite.core.api.objects.EventPlayer;
 import dev.imabad.mceventsuite.core.api.objects.EventRank;
 import dev.imabad.mceventsuite.core.modules.mysql.MySQLDatabase;
-import javassist.NotFoundException;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
-
-import javax.persistence.NoResultException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class RankDAO extends DAO {
 
-    private List<EventRank> ranks;
+    private Map<Integer, EventRank> ranks;
 
     public RankDAO(MySQLDatabase mySQLDatabase){
         super(mySQLDatabase);
@@ -26,44 +28,144 @@ public class RankDAO extends DAO {
         if(ranks == null){
             getRanks(true);
         }
-        return ranks.stream().filter(eventRank -> eventRank.getName().equalsIgnoreCase(name)).findFirst();
+        return ranks.values().stream().filter(eventRank -> eventRank.getName().equalsIgnoreCase(name)).findFirst();
     }
 
-    public List<EventRank> getRanks(){
-        if(ranks != null){
+    public Map<Integer, EventRank> getRanks(boolean forceRefresh){
+        if(ranks != null && !forceRefresh){
             return ranks;
         }
-        Session session = mySQLDatabase.getSession();
-        try {
-            ranks = session.createQuery("select r from EventRank r", EventRank.class).list();
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM ranks INNER JOIN EventRank_permissions ON ranks.id=EventRank_permissions.EventRank_id");
+            ResultSet resultSet = statement.executeQuery();
+            Map<Integer, EventRank> rankMap = new HashMap<>();
+            while(resultSet.next()){
+                int id = resultSet.getInt("id");
+                EventRank rank = rankMap.get(id);
+                if(rank == null){
+                    String name = resultSet.getString("name");
+                    boolean inheritsFromBelow = resultSet.getBoolean("inheritsFromBelow");
+                    int power = resultSet.getInt("power");
+                    String prefix = resultSet.getString("prefix");
+                    String suffix = resultSet.getString("suffix");
+                    String chatColor = resultSet.getString("chatColor");
+                    List<String> permissions = new ArrayList<>();
+                    rank = new EventRank(id, power, name, prefix, suffix, permissions, inheritsFromBelow, chatColor);
+                    rankMap.put(id, rank);
+                }
+                rank.getPermissions().add(resultSet.getString("permissions"));
+            }
+            ranks = rankMap;
             return ranks;
-        } finally {
-            session.close();
+        } catch(SQLException sqlException){
+            sqlException.printStackTrace();
+            return Collections.emptyMap();
         }
     }
 
-    public List<EventRank> getRanks(boolean refresh){
-        if(!refresh){
-            return getRanks();
+    public EventRank getRankByID(int id){
+        return getRanks().get(id);
+    }
+
+    public Map<Integer, EventRank> getRanks(){
+        return getRanks(false);
+    }
+
+    public boolean insertRank(EventRank rank){
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement insertStatement = connection.prepareStatement("INSERT INTO ranks (power, name, inheritsFromBelow, prefix, suffix, chatColor) VALUES (?, ?, ?, ?, ?, ?);");
+            insertStatement.setInt(1, rank.getPower());
+            insertStatement.setString(2, rank.getName());
+            insertStatement.setBoolean(3, rank.isInheritsFromBelow());
+            insertStatement.setString(4, rank.getPrefix());
+            insertStatement.setString(5, rank.getSuffix());
+            insertStatement.setString(6, rank.getChatColor());
+            if(insertStatement.executeUpdate() == 0){
+                return false;
+            }
+            try (ResultSet generatedKeys = insertStatement.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    int newID = generatedKeys.getInt(1);
+                    rank.setId(newID);
+                    updateRankPermissions(rank);
+                    return true;
+                }
+                else {
+                    throw new SQLException("Creating user failed, no ID obtained.");
+                }
+            }
+        }catch(SQLException exception){
+            //TODO: Add proper logging
+            exception.printStackTrace();
         }
-        Session session = mySQLDatabase.getSession();
-        try {
-            ranks = session.createQuery("select r from EventRank r", EventRank.class).list();
-            return ranks;
-        } finally {
-            session.close();
+        return false;
+    }
+
+    public void updateRank(EventRank rank){
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement insertStatement = connection.prepareStatement("UPDATE ranks SET power = ?, name = ?, inheritsFromBelow = ?, prefix = ? suffix = ?, chatColor = ? WHERE id = ?");
+            insertStatement.setInt(1, rank.getPower());
+            insertStatement.setString(2, rank.getName());
+            insertStatement.setBoolean(3, rank.isInheritsFromBelow());
+            insertStatement.setString(4, rank.getPrefix());
+            insertStatement.setString(5, rank.getSuffix());
+            insertStatement.setString(6, rank.getChatColor());
+            insertStatement.setInt(7, rank.getId());
+            insertStatement.executeUpdate();
+            updateRankPermissions(rank);
+        }catch(SQLException exception){
+            //TODO: Add proper logging
+            exception.printStackTrace();
         }
     }
 
-    public void saveRank(EventRank rank){
-        Transaction tx = null;
-        try (Session session = mySQLDatabase.getSession()) {
-            tx = session.beginTransaction();
-            session.saveOrUpdate(rank);
-            tx.commit(); // Flush happens automatically
-        } catch (RuntimeException e) {
-            assert tx != null;
-            tx.rollback();
+    public Collection<String> getRankPermissions(EventRank rank){
+        try(Connection connection = mySQLDatabase.getSession()){
+            PreparedStatement selectStatement = connection.prepareStatement("SELECT permissions FROM EventRank_permissions WHERE EventRank_id = ?");
+            selectStatement.setInt(1, rank.getId());
+            ResultSet resultSet = selectStatement.executeQuery();
+            Collection<String> permissions = new ArrayList<>();
+            while(resultSet.next()){
+                permissions.add(resultSet.getString("permissions"));
+            }
+            return permissions;
+        }catch (SQLException e){
+            return Collections.emptyList();
+        }
+    }
+
+    public void updateRankPermissions(EventRank rank){
+        try(Connection connection = mySQLDatabase.getSession()){
+            Collection<String> toAdd = rank.getPermissions();
+            if(rank.getId() != 0){
+                Collection<String> existingPermissions = getRankPermissions(rank);
+                toAdd = toAdd.stream().filter(s -> !existingPermissions.contains(s)).collect(
+                    Collectors.toList());
+                Collection<String> toRemove = existingPermissions.stream().filter(s -> !rank.getPermissions().contains(s)).collect(
+                    Collectors.toList());
+                if(!toRemove.isEmpty()){
+                    PreparedStatement removeStatement = connection.prepareStatement("DELETE FROM EventRank_permissions WHERE EventRank_id = ? AND permissions IN (?)");
+                    removeStatement.setInt(1, rank.getId());
+                    removeStatement.setArray(2, connection.createArrayOf("VARCHAR", toRemove.toArray()));
+                    removeStatement.executeUpdate();
+                }
+            }
+            if(!toAdd.isEmpty()){
+                PreparedStatement addStatement = connection.prepareStatement("INSERT INTO EventRank_permissions VALUES(?,?)");
+                addStatement.setInt(1, rank.getId());
+                toAdd.forEach(s -> {
+                    try {
+                        addStatement.setString(2, s);
+                        addStatement.addBatch();
+                    } catch(SQLException exception){
+                        exception.printStackTrace();
+                    }
+                });
+                addStatement.executeBatch();
+            }
+        }catch(SQLException exception){
+            //TODO: Add proper logging
+            exception.printStackTrace();
         }
     }
 
@@ -74,6 +176,6 @@ public class RankDAO extends DAO {
         if(ranks.size() < 1){
             return Optional.of(new EventRank(0, "Default", "", "", Collections.emptyList()));
         }
-        return ranks.stream().min(Comparator.comparingInt(EventRank::getPower));
+        return ranks.values().stream().min(Comparator.comparingInt(EventRank::getPower));
     }
 }


### PR DESCRIPTION
This PR will remove hibernate from the core and replace it with our own SQL queries and logic using HikariCP.

Why are we removing Hibernate?
Mostly due to the complexities it brings when debugging problems as well as the increase in size to the build jars.

TODO:
- [x] Remove Hibernate
- [x] Re-write base DAO's
   - [x] Player DAO
   - [x] Rank DAO
   - [x] Settings DAO
- [ ] Re-write module DAO's
   - [ ] Booth DAO
   - [ ] DiscordLink DAO
   - [ ] AccessControl DAO
   - [ ] AuditLog DAO
   - [ ] PlayerBan DAO
   - [ ] EventPass DAO
   - [ ] ScheduledAnnouncements DAO
- [ ] Ensure existing logic works correctly

Once this PR is complete, we can then start to re-organize code and split out modules from the core.